### PR TITLE
build: dynamically resolve AAPT2 path with local.properties support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,4 @@ systemProp.file.encoding=UTF-8
 systemProp.sun.jnu.encoding=UTF-8
 systemProp.user.country=US
 
-android.aapt2FromMavenOverride=/data/data/com.termux/files/usr/bin/aapt2
+# android.aapt2FromMavenOverride=/data/data/com.termux/files/usr/bin/aapt2

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,8 +17,22 @@
  */
 
 val aapt2OverrideKey = "android.aapt2FromMavenOverride"
+
+// 1. Read from gradle properties (command line or gradle.properties)
+val gradleAapt2 = providers.gradleProperty(aapt2OverrideKey).orNull
+
+// 2. Read from local.properties
+val localPropertiesFile = java.io.File(rootDir, "local.properties")
+val localAapt2 = if (localPropertiesFile.exists()) {
+    java.util.Properties().apply {
+        localPropertiesFile.inputStream().use { load(it) }
+    }.getProperty(aapt2OverrideKey)
+} else null
+
+// 3. Find first path that actually exists on disk
 val customAapt2 = listOf(
-    providers.gradleProperty(aapt2OverrideKey).orNull,
+    gradleAapt2,
+    localAapt2,
     "/usr/bin/aapt2",
     "/data/data/com.termux/files/usr/bin/aapt2"
 ).filterNotNull().firstOrNull { java.io.File(it).exists() }


### PR DESCRIPTION
Comments out the hardcoded dynamic AAPT2 path override in gradle.properties, allowing non-Termux systems (PCs/CI pipelines) to fallback to the default Maven-provided AAPT2 correctly.

Updates settings.gradle.kts to search for AAPT2 in priority order:
1. Command line/gradle.properties overrides
2. local.properties override
3. /usr/bin/aapt2 (isolated container path)
4. /data/data/com.termux/files/usr/bin/aapt2 (Termux host path)

Only overrides 'android.aapt2FromMavenOverride' if the target executable actually exists on disk, ensuring compatibility across all build systems.