### PR TITLE
feat: add permissions check and request helper, integrate install per…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,9 @@
     <!-- 安装与后台服务 -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"
         tools:ignore="RequestInstallPackagesPolicy" />
+    <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <!-- 相机特性声明 -->

--- a/app/src/main/java/com/scto/mobile/ide/core/utils/PermissionHelper.kt
+++ b/app/src/main/java/com/scto/mobile/ide/core/utils/PermissionHelper.kt
@@ -1,0 +1,87 @@
+/*
+ * MobileIDE - A powerful IDE for Android app development.
+ * Copyright (C) 2025  scto  <tschmid35@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.scto.mobile.ide.core.utils
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+
+object PermissionHelper {
+
+    /** Checks if the app can request package installations. */
+    fun hasInstallPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.packageManager.canRequestPackageInstalls()
+        } else {
+            true
+        }
+    }
+
+    /** Checks if the WakeLock permission is granted. */
+    fun hasWakeLockPermission(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.WAKE_LOCK) ==
+            PackageManager.PERMISSION_GRANTED
+    }
+
+    /** Checks if the Foreground Service permission is granted. */
+    fun hasForegroundServicePermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.FOREGROUND_SERVICE) ==
+                PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    /** Checks if the Request Delete Packages permission is declared/granted. */
+    fun hasDeletePackagesPermission(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.REQUEST_DELETE_PACKAGES) ==
+                PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+    }
+
+    /** Composable helper to remember and trigger package install permission request. */
+    @Composable
+    fun rememberInstallPermissionRequest(onPermissionResult: (Boolean) -> Unit): () -> Unit {
+        val context = LocalContext.current
+        val launcher =
+            rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) {
+                onPermissionResult(hasInstallPermission(context))
+            }
+
+        return {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val intent =
+                    Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES).apply {
+                        data = android.net.Uri.parse("package:${context.packageName}")
+                    }
+                try {
+                    launcher.launch(intent)
+                } catch (e: Exception) {
+                    android.util.Log.e("PermissionHelper", "Failed to launch ACTION_MANAGE_UNKNOWN_APP_SOURCES", e)
+                }
+            } else {
+                onPermissionResult(true)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/scto/mobile/ide/ui/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/scto/mobile/ide/ui/welcome/WelcomeScreen.kt
@@ -40,13 +40,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.scto.mobile.ide.R
+import com.scto.mobile.ide.core.utils.PermissionHelper
 import com.scto.mobile.ide.core.utils.PermissionManager
 import com.scto.mobile.ide.ui.ThemeViewModel
 import com.scto.mobile.ide.ui.components.ColorPickerDialog
@@ -56,13 +59,14 @@ import kotlinx.coroutines.launch
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun WelcomeScreen(themeViewModel: ThemeViewModel, onWelcomeFinished: () -> Unit) {
+    val context = LocalContext.current
     val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
     val themeState by themeViewModel.themeState.collectAsState()
     val scope = rememberCoroutineScope()
     val pagerState = rememberPagerState(pageCount = { 3 })
 
-    var storageGranted by remember { mutableStateOf(false) }
-    var installGranted by remember { mutableStateOf(true) }
+    var storageGranted by remember { mutableStateOf(PermissionManager.hasRequiredPermissions(context)) }
+    var installGranted by remember { mutableStateOf(PermissionHelper.hasInstallPermission(context)) }
 
     var showColorPicker by remember { mutableStateOf(false) }
     var customColor by remember { mutableStateOf(themeState.customColor) }
@@ -148,9 +152,14 @@ fun WelcomeScreen(themeViewModel: ThemeViewModel, onWelcomeFinished: () -> Unit)
             onPermissionGranted = { storageGranted = true },
             onPermissionDenied = {},
         )
+    val requestInstallPermission =
+        PermissionHelper.rememberInstallPermissionRequest { granted -> installGranted = granted }
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) storageGranted = permissionState.hasPermissions()
+            if (event == Lifecycle.Event.ON_RESUME) {
+                storageGranted = permissionState.hasPermissions()
+                installGranted = PermissionHelper.hasInstallPermission(context)
+            }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
@@ -213,7 +222,7 @@ fun WelcomeScreen(themeViewModel: ThemeViewModel, onWelcomeFinished: () -> Unit)
                                 storageGranted = storageGranted,
                                 installGranted = installGranted,
                                 onRequestStoragePermission = { permissionState.requestPermissions() },
-                                onRequestInstallPermission = { /* ... */ },
+                                onRequestInstallPermission = requestInstallPermission,
                             )
 
                         2 ->

--- a/gradlew
+++ b/gradlew
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 
-
+# Dynamic AAPT2 path resolution for Termux/container environments
+if [ -f "/usr/bin/aapt2" ]; then
+    set -- "$@" "-Pandroid.aapt2FromMavenOverride=/usr/bin/aapt2"
+elif [ -f "/data/data/com.termux/files/usr/bin/aapt2" ]; then
+    set -- "$@" "-Pandroid.aapt2FromMavenOverride=/data/data/com.termux/files/usr/bin/aapt2"
+fi
 
 ##############################################################################
 ##

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,32 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-val aapt2OverrideKey = "android.aapt2FromMavenOverride"
 
-// 1. Read from gradle properties (command line or gradle.properties)
-val gradleAapt2 = providers.gradleProperty(aapt2OverrideKey).orNull
-
-// 2. Read from local.properties
-val localPropertiesFile = java.io.File(rootDir, "local.properties")
-val localAapt2 = if (localPropertiesFile.exists()) {
-    java.util.Properties().apply {
-        localPropertiesFile.inputStream().use { load(it) }
-    }.getProperty(aapt2OverrideKey)
-} else null
-
-// 3. Find first path that actually exists on disk
-val customAapt2 = listOf(
-    gradleAapt2,
-    localAapt2,
-    "/usr/bin/aapt2",
-    "/data/data/com.termux/files/usr/bin/aapt2"
-).filterNotNull().firstOrNull { java.io.File(it).exists() }
-
-if (customAapt2 != null) {
-    gradle.beforeProject {
-        extensions.extraProperties.set(aapt2OverrideKey, customAapt2)
-    }
-}
 
 pluginManagement {
     repositories {


### PR DESCRIPTION
…mission in WelcomeScreen, and optimize Termux AAPT2 resolution

- Added REQUEST_DELETE_PACKAGES, WAKE_LOCK, and FOREGROUND_SERVICE permissions to AndroidManifest.xml.
- Implemented PermissionHelper utility to check new permissions and request package installation permission.
- Integrated PermissionHelper in WelcomeScreen onboarding flow.
- Moved AAPT2 Maven override lookup to gradlew wrapper arguments to prevent Gradle config/transform phase failures.